### PR TITLE
Improve coalesce_regex

### DIFF
--- a/src/pep505/hook.py
+++ b/src/pep505/hook.py
@@ -49,7 +49,7 @@ from . import parser as python_parser
 
 
 PEP505_DEBUG = os.getenv('PYTHON_PEP505_DEBUG')
-COALESCE_REGEX = re.compile(r'\n#\s+-\*- parsing: pep505 -\*-')
+COALESCE_REGEX = re.compile(r'(?:^|\n)#\s+-\*- parsing: pep505 -\*-')
 FULLNAME_TO_LOADER = {}
 
 


### PR DESCRIPTION
Thank you for continuing the work on PEP 505! I'm very much looking forward to it. I believe this would be a great addition to Python, although admittedly a more advanced feature.

While doing some initial tests, I noticed that it wasn't picking up `# -*- parsing: pep505 -*-`. Turns out since I placed it in the first line, there wasn't any `\n` to match against. Using `(?:^|\n)` instead should fix that.